### PR TITLE
Use parallel parquet generation with ohsome-planet and better compression with duckdb

### DIFF
--- a/.github/workflows/geoparquet-snapshots.yaml
+++ b/.github/workflows/geoparquet-snapshots.yaml
@@ -91,7 +91,7 @@ jobs:
           PBF="planet-${TAG}.osm.pbf"
           OUT_DIR="ohsome-${TAG}"
           time java -Xmx32g -jar "$JAR_PATH" contributions \
-               --pbf "$PBF" --output "$OUT_DIR" --overwrite
+               --pbf "$PBF" --parallel=$(nproc) --output "$OUT_DIR" --overwrite
           
           # list everything just produced
           echo "::group::Produced files"
@@ -106,7 +106,7 @@ jobs:
           duckdb.sql(
               f"COPY (SELECT * FROM parquet_scan('{glob_pat}')) "
               f"TO 'planet-{tag}.osm.parquet' "
-              " (FORMAT PARQUET, COMPRESSION ZSTD);"
+              " (FORMAT PARQUET, COMPRESSION ZSTD, COMPRESSION_LEVEL 20, PARQUET_VERSION v2);"
           )
           PY
 

--- a/.github/workflows/geoparquet-snapshots.yaml
+++ b/.github/workflows/geoparquet-snapshots.yaml
@@ -104,7 +104,7 @@ jobs:
           tag = os.environ["TAG"]
           glob_pat = f"ohsome-{tag}/contributions/latest/*.parquet"
           duckdb.sql(
-              f"COPY (SELECT * FROM parquet_scan('{glob_pat}')) "
+              f"COPY (FROM parquet_scan('{glob_pat}') ORDER BY bbox.xmin, bbox.ymin, bbox.xmax, bbox.ymax) "
               f"TO 'planet-{tag}.osm.parquet' "
               " (FORMAT PARQUET, COMPRESSION ZSTD, COMPRESSION_LEVEL 20, PARQUET_VERSION v2);"
           )


### PR DESCRIPTION
Hey and sorry for creating the PR #2 without actually testing it fully. Thanks for moving forward with this still without me.

I also realized that quackosm is not good enough for this and ended up using `ohsome-planet`. It had performance issues and it also removed items like bus lines:
https://github.com/kraina-ai/quackosm/issues/248

* Using all cores for `ohsome-planet` should make it faster.
* Ordering the data according to the bbox the resulting parquet file will be both smaller and faster to access. This is the same pattern as how Overturemaps orders their parquet files.
* Using higher compression value for zstd (20 instead of default 4) and parquet version 2 should again make the files a bit more smaller.

